### PR TITLE
fix(types): add tsconfig so tsc --noEmit can typecheck

### DIFF
--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020", "DOM"],
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": ["index.d.ts"]
+}


### PR DESCRIPTION
## Outcome

**Fix** — restore `@defai/element-types` `tsc --noEmit` / `npm test` so the published element type definitions can be typechecked.

Package: `types` (`@defai/element-types`). Inheritance-app path: typed element contracts (permissions, host APIs, notifications, wallet/portfolio surfaces declared in `index.d.ts`). Without a project file, the package test cannot typecheck those contracts.

Related to https://github.com/heirlabs/element-sdk/issues/1 (the missing `types/tsconfig.json` half). This PR does **not** remove tracked `node_modules/` or change `.gitignore`, so it does not close #1.

Leave approval and merge to `main` to `awidearray`. Not accepted until that merge.

## Change

Add only `types/tsconfig.json` so `tsc --noEmit` loads `index.d.ts`. `lib` includes `DOM` because the definitions use `RequestInit`, `Response`, `WebSocket`, and Notification types.

No sandbox, proxy, validator, iframe, `@defai` rename, or tracked `node_modules`/`lib` edits.

## Evidence

Head: `98e1adc9c3b0e9d5e86689b17f6add32c9ab6f1e`  
Base: `51a5d6eb16ce58e3d9d8866a7bb5c0af356abe7a` (`origin/main`)

### Fail (before, at `51a5d6eb`)

```text
$ cd types && ../node_modules/.bin/tsc --noEmit
# prints tsc help (no project / no input files)
exit 1

$ cd types && ../node_modules/.bin/tsc --noEmit -p . --pretty false
error TS5057: Cannot find a tsconfig.json file at the specified directory: '.'.
exit 1
```

### Pass (after, at `98e1adc9`)

```text
$ cd types && ../node_modules/.bin/tsc --noEmit
exit 0

$ cd types && ../node_modules/.bin/tsc --noEmit -p .
exit 0

$ cd types && npm test
> @defai/element-types@1.0.0 test
> tsc --noEmit
exit 0
```

The package test *is* `tsc --noEmit`. No extra test file.

## Remains untested / out of scope

- Tracked `node_modules/` and missing `.gitignore` rules from #1
- Sandbox `postMessage(..., '*')` and unfiltered `createAPIProxy()` host methods
- Validator does not deny unknown permission keys
- Full-repo `npm run build` / `npm run test` not claimed (would pull the node_modules / missing-workspace noise)

## Identity

- Client: Cursor
- Provider: xai
- Model: cursor-grok-4.6

## Receipt / private trace

A scored Slop run could not start. `terms-preflight.mjs` and `run-receipt.mjs start` both failed with:

```text
project terms preflight failed: new runs are paused until repository authority is verified
```

Live `https://slop.cash/projects/heir-elements-sdk/terms.json` reports `status: paused`, `authority.state: unverified` (`missing-repository-proof`), `receiptPolicy.state: pending-authority-activation`.

No receipt footer is attached. None was invented. This GitHub PR is the public Fix artifact only; it is not a scored contribution until authority is verified and a measured run can finish.


Made with [Cursor](https://cursor.com)