### PR TITLE
fix(sandbox): scope element API proxy to granted permissions

### DIFF
--- a/sdk/jest.config.js
+++ b/sdk/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+};

--- a/sdk/src/sandbox/ElementSandbox.test.ts
+++ b/sdk/src/sandbox/ElementSandbox.test.ts
@@ -1,0 +1,93 @@
+import { ElementSandbox } from './ElementSandbox';
+import { ElementPermissions } from '../interfaces';
+
+/**
+ * `createAPIProxy` is private and returns the JS source string injected into
+ * the sandboxed iframe as `window.elementAPI`. It's tested directly (via a
+ * cast) rather than through `loadElement`, since building the srcdoc HTML
+ * requires a DOM (`document.createElement('iframe')`) that this package's
+ * jest setup doesn't provide, and the method itself never touches the DOM.
+ */
+function proxyMethodNames(permissions: ElementPermissions): string[] {
+  const sandbox = new ElementSandbox('test-element', permissions);
+  const source = (sandbox as unknown as { createAPIProxy(): string }).createAPIProxy();
+  // Each exposed method is emitted as a top-level `name: function(...args) {`
+  // entry; the generated function bodies never contain that exact sequence
+  // themselves, so this reliably recovers just the proxy's own keys without
+  // needing a full (non-JSON) object-literal parser.
+  return Array.from(source.matchAll(/(\w+): function\(/g), (match) => match[1]);
+}
+
+const NO_PERMISSIONS: ElementPermissions = {
+  network: false,
+  storage: false,
+  notifications: false,
+  clipboard: false,
+  canReceiveFrom: [],
+  canSendTo: [],
+  portfolio: false,
+  transactions: false,
+  aiChat: false,
+  wallet: false
+};
+
+describe('ElementSandbox createAPIProxy permission scoping', () => {
+  it('exposes no gated methods when no permissions are granted', () => {
+    const methods = proxyMethodNames(NO_PERMISSIONS);
+    expect(methods).toEqual(['on']);
+  });
+
+  it('exposes only getPortfolio when portfolio permission is granted', () => {
+    const methods = proxyMethodNames({ ...NO_PERMISSIONS, portfolio: true });
+    expect(methods).toEqual(expect.arrayContaining(['getPortfolio', 'on']));
+    expect(methods).not.toContain('getTransactions');
+    expect(methods).not.toContain('saveData');
+  });
+
+  it('exposes saveData and loadData together when storage permission is granted', () => {
+    const methods = proxyMethodNames({ ...NO_PERMISSIONS, storage: true });
+    expect(methods).toEqual(expect.arrayContaining(['saveData', 'loadData', 'on']));
+    expect(methods).not.toContain('getPortfolio');
+  });
+
+  it('exposes analyzeImage and analyzeToken together when aiChat permission is granted', () => {
+    const methods = proxyMethodNames({ ...NO_PERMISSIONS, aiChat: true });
+    expect(methods).toEqual(expect.arrayContaining(['analyzeImage', 'analyzeToken', 'on']));
+  });
+
+  it('exposes emit only when canSendTo is non-empty', () => {
+    const withoutTargets = proxyMethodNames(NO_PERMISSIONS);
+    expect(withoutTargets).not.toContain('emit');
+
+    const withTargets = proxyMethodNames({ ...NO_PERMISSIONS, canSendTo: ['other-element'] });
+    expect(withTargets).toContain('emit');
+  });
+
+  it('exposes every gated method when every corresponding permission is granted', () => {
+    const methods = proxyMethodNames({
+      ...NO_PERMISSIONS,
+      network: true,
+      storage: true,
+      notifications: true,
+      portfolio: true,
+      transactions: true,
+      aiChat: true,
+      canSendTo: ['*']
+    });
+    expect(methods).toEqual(
+      expect.arrayContaining([
+        'getPortfolio',
+        'getTransactions',
+        'getPrices',
+        'saveData',
+        'loadData',
+        'sendNotification',
+        'analyzeImage',
+        'analyzeToken',
+        'emit',
+        'on'
+      ])
+    );
+    expect(methods).toHaveLength(10);
+  });
+});

--- a/sdk/src/sandbox/ElementSandbox.ts
+++ b/sdk/src/sandbox/ElementSandbox.ts
@@ -161,20 +161,27 @@ export class ElementSandbox {
 
   /**
    * Create API proxy for the element
+   *
+   * Only exposes methods the element's declared permissions actually allow.
+   * This must mirror ElementAPIProxy's own permission checks so an element
+   * never sees a client-side API surface wider than what the host will
+   * honor. `on` is always exposed: registering a handler isn't itself
+   * privileged, ElementAPIProxy filters delivered payloads by
+   * canReceiveFrom.
    */
   private createAPIProxy(): string {
     const methods = [
-      'getPortfolio',
-      'getTransactions',
-      'getPrices',
-      'saveData',
-      'loadData',
-      'sendNotification',
-      'analyzeImage',
-      'analyzeToken',
-      'emit',
+      this.permissions.portfolio && 'getPortfolio',
+      this.permissions.transactions && 'getTransactions',
+      this.permissions.network && 'getPrices',
+      this.permissions.storage && 'saveData',
+      this.permissions.storage && 'loadData',
+      this.permissions.notifications && 'sendNotification',
+      this.permissions.aiChat && 'analyzeImage',
+      this.permissions.aiChat && 'analyzeToken',
+      this.permissions.canSendTo.length > 0 && 'emit',
       'on'
-    ];
+    ].filter((method): method is string => typeof method === 'string');
 
     const proxy: any = {};
     


### PR DESCRIPTION
## What changed

`ElementSandbox.createAPIProxy()` builds the `window.elementAPI` object injected into every sandboxed element's iframe (see `loadElement()`). It exposed an unconditional, hardcoded list of all 10 host API methods (`getPortfolio`, `getTransactions`, `getPrices`, `saveData`, `loadData`, `sendNotification`, `analyzeImage`, `analyzeToken`, `emit`, `on`) regardless of the element's declared `ElementPermissions` — even though `this.permissions` is already read elsewhere in the same class to gate the iframe's sandbox attributes (`allow-clipboard-read`/`allow-clipboard-write`) and CSP (`connect-src *` for network).

`ElementAPIProxy` independently enforces the correct per-method permission checks (`getPortfolio` requires `permissions.portfolio`, `saveData`/`loadData` require `permissions.storage`, etc.), so a host that correctly wires the sandbox's `api-call` messages through `ElementAPIProxy` won't actually execute an unpermitted call. But:

- The sandboxed element's own client-side `elementAPI` object never reflects what it was actually granted — every element sees the same full 10-method surface no matter its permissions, which is misleading and makes it easy for an element to attempt calls it has no business making.
- Any host implementation that wires the sandbox's messages to the raw `actualAPI` instead of through `ElementAPIProxy` gets **no enforcement at all** — nothing in `ElementSandbox` itself stops it.

## Fix

Filter the exposed method list by the same permission fields `ElementAPIProxy` checks: `portfolio`, `transactions`, `network`, `storage` (for both `saveData`/`loadData`), `notifications`, `aiChat` (for both `analyzeImage`/`analyzeToken`), and `canSendTo.length > 0` for `emit`. `on` stays unconditional — registering a handler isn't itself privileged; `ElementAPIProxy.on` already filters delivered payloads by `canReceiveFrom` at dispatch time, not at registration.

## Also: `sdk/jest.config.js`

`sdk/package.json` declares `ts-jest` as a devDependency, but there was no jest config anywhere wiring it up as the transform — so no TypeScript test file could actually run in this package. This was invisible because `"test": "jest --passWithNoTests"` passes trivially when zero test files exist (confirmed: adding a plain `.test.ts` file failed with a babel parse error on TS type syntax before this config existed).

This gap is repo-wide — `react`, `cli`, `validator`, `testing`, and `templates` all declare `ts-jest` the same way with no config wiring it up either — but this PR only adds the config to `sdk`, the package being touched here, to stay scoped to this fix. Worth its own issue for the rest.

## Verification

- New test file `sdk/src/sandbox/ElementSandbox.test.ts`, 6 cases covering: no permissions → only `on`; single-permission grants (`portfolio`, `storage`, `aiChat`); `emit` gated on non-empty `canSendTo`; and the full-permissions case exposing all 10.
- **Mutation check**: reverted just the `ElementSandbox.ts` fix and reran — 4 of 6 tests fail against the unpatched code, each showing the exact leak (e.g. `getPortfolio` present with zero permissions granted). Restored the fix, all 6 pass. (The other 2 tests are positive-only checks that don't discriminate old/new behavior by design.)
- Full `sdk` test suite: 6/6 pass, no collateral tests exist yet in this package.
- `tsc --noEmit`: clean.
- `eslint`: not runnable — no ESLint config exists anywhere in this repo (`npm init @eslint/config` was never run), which is pre-existing and unrelated to this change.

## Scope

Deliberately narrow: only `ElementSandbox.createAPIProxy()`'s method-list construction changed. `ElementAPIProxy`'s own permission logic, the sandbox's CSP/iframe-attribute logic, and the `postMessage` transport were left untouched.

## Provenance

AI-assisted (Claude, `claude-sonnet-5`, Claude Code). The permission-enforcement gap was found by reading `ElementSandbox.ts` and cross-referencing it against `ElementAPIProxy.ts`'s actual per-method checks myself, not from an external claim. All verification above (mutation testing, full-suite run, typecheck) was run and read by me before opening this PR.
