### PR TITLE
fix(sdk): reject unknown permission keys

### DIFF
--- a/sdk/jest.config.js
+++ b/sdk/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+};

--- a/sdk/lib/core/ElementValidator.js
+++ b/sdk/lib/core/ElementValidator.js
@@ -84,6 +84,29 @@ class ElementValidator {
             });
         }
         else {
+            const declaredPermissionKeys = new Set([
+                'network',
+                'storage',
+                'notifications',
+                'clipboard',
+                'canReceiveFrom',
+                'canSendTo',
+                'portfolio',
+                'transactions',
+                'aiChat',
+                'wallet',
+                'maxMemory',
+                'maxCpu'
+            ]);
+            Object.keys(manifest.permissions).forEach(permission => {
+                if (!declaredPermissionKeys.has(permission)) {
+                    errors.push({
+                        code: 'UNKNOWN_PERMISSION',
+                        message: `Unknown permission: ${permission}`,
+                        field: `permissions.${permission}`
+                    });
+                }
+            });
             // Check for excessive permissions
             const permissionCount = Object.values(manifest.permissions).filter(v => v === true).length;
             if (permissionCount > 5) {

--- a/sdk/src/core/ElementValidator.test.ts
+++ b/sdk/src/core/ElementValidator.test.ts
@@ -1,0 +1,68 @@
+import { ElementValidator } from './ElementValidator';
+import { ElementManifest, ElementPermissions } from '../interfaces';
+
+const permissions: ElementPermissions = {
+  network: false,
+  storage: false,
+  notifications: false,
+  clipboard: false,
+  canReceiveFrom: [],
+  canSendTo: [],
+  portfolio: false,
+  transactions: false,
+  aiChat: false,
+  wallet: false
+};
+
+function manifestWithPermissions(
+  manifestPermissions: ElementManifest['permissions']
+): ElementManifest {
+  return {
+    metadata: {
+      id: 'validator-test',
+      name: 'Validator Test',
+      version: '1.0.0',
+      author: 'Test Author',
+      description: 'Validator test element',
+      category: 'Utilities',
+      tags: [],
+      icon: 'test',
+      minSize: { width: 100, height: 100 },
+      maxSize: { width: 500, height: 500 },
+      defaultSize: { width: 200, height: 200 },
+      tierRequired: 'free'
+    },
+    permissions: manifestPermissions
+  };
+}
+
+describe('ElementValidator permission keys', () => {
+  it('rejects every unknown permission key', () => {
+    const result = ElementValidator.validateManifest(
+      manifestWithPermissions({ ...permissions, filesystem: true, camera: false } as ElementPermissions)
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual(expect.arrayContaining([
+      {
+        code: 'UNKNOWN_PERMISSION',
+        message: 'Unknown permission: filesystem',
+        field: 'permissions.filesystem'
+      },
+      {
+        code: 'UNKNOWN_PERMISSION',
+        message: 'Unknown permission: camera',
+        field: 'permissions.camera'
+      }
+    ]));
+  });
+
+  it('accepts the complete declared permission contract', () => {
+    const result = ElementValidator.validateManifest(
+      manifestWithPermissions({ ...permissions, maxMemory: 50, maxCpu: 10 })
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.valid).toBe(true);
+  });
+});

--- a/sdk/src/core/ElementValidator.ts
+++ b/sdk/src/core/ElementValidator.ts
@@ -93,6 +93,31 @@ export class ElementValidator {
         message: 'Element manifest must include permissions'
       });
     } else {
+      const declaredPermissionKeys = new Set([
+        'network',
+        'storage',
+        'notifications',
+        'clipboard',
+        'canReceiveFrom',
+        'canSendTo',
+        'portfolio',
+        'transactions',
+        'aiChat',
+        'wallet',
+        'maxMemory',
+        'maxCpu'
+      ]);
+
+      Object.keys(manifest.permissions).forEach(permission => {
+        if (!declaredPermissionKeys.has(permission)) {
+          errors.push({
+            code: 'UNKNOWN_PERMISSION',
+            message: `Unknown permission: ${permission}`,
+            field: `permissions.${permission}`
+          });
+        }
+      });
+
       // Check for excessive permissions
       const permissionCount = Object.values(manifest.permissions).filter(v => v === true).length;
       if (permissionCount > 5) {
@@ -245,4 +270,4 @@ export class ElementValidator {
     
     return true;
   }
-} 
+}


### PR DESCRIPTION
## Outcome

**Fix / Prove**: make `ElementValidator` fail closed when an untrusted manifest contains permission names outside the declared `ElementPermissions` contract.

Workspace: `sdk`. Protected inheritance-app path: validation of host-capability declarations before an element reaches wallet, storage, network, notification, AI, portfolio, transaction, or messaging surfaces.

Closes #7.

## Change

- Reject every unknown permission key with a field-specific `UNKNOWN_PERMISSION` error.
- Preserve all declared boolean, communication-list, and resource-limit keys.
- Add real SDK tests for multiple unknown keys and a complete declared-key control manifest.
- Add the SDK's missing `ts-jest` configuration so TypeScript validator tests execute.
- Update the tracked compiled `sdk/lib` validator artifact.

No permissions are widened and no runtime host API is added.

## Evidence

Head: `e5d5df2097e0470b6231d97c1121c0036d231215`  
Base: `51a5d6eb16ce58e3d9d8866a7bb5c0af356abe7a`

Before the fix, the issue reproduction returned:

```json
{"valid":true,"errors":[],"warnings":[]}
```

At the committed head:

```text
npm test --workspace @defai/element-sdk -- --runInBand
Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
```

```text
npm run build --workspace @defai/element-sdk
> tsc
exit 0
```

```text
npm run build
Successfully ran target build for 7 projects
```

`npm run test` remains blocked before the SDK lane by the existing issue #1: `@defai/element-types` runs `tsc --noEmit` without a `tsconfig`, prints TypeScript help, and exits 1. Lerna then skips the remaining workspace tests. The focused SDK test above runs independently and passes.

## Identity

- Provider: `cx`
- Model: `9routerr/cx/gpt-5.6-sol`
- Client: `opencode`

Leave final approval and merge to `main` to `awidearray`. This is not accepted until that independent merge.
