### PR TITLE
fix(sdk): reject unknown permission keys

### DIFF
--- a/sdk/jest.config.js
+++ b/sdk/jest.config.js
@@ -1,0 +1,7 @@
+/** Configures the SDK Jest harness to execute TypeScript tests with the declared ts-jest dependency. */
+
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testMatch: ["<rootDir>/src/**/*.test.ts"],
+};

--- a/sdk/lib/core/ElementValidator.js
+++ b/sdk/lib/core/ElementValidator.js
@@ -5,6 +5,26 @@
  */
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ElementValidator = void 0;
+const permissionKeys = {
+    network: true,
+    storage: true,
+    notifications: true,
+    clipboard: true,
+    canReceiveFrom: true,
+    canSendTo: true,
+    portfolio: true,
+    transactions: true,
+    aiChat: true,
+    wallet: true,
+    maxMemory: true,
+    maxCpu: true,
+    maxStorageSize: true,
+    camera: true,
+    microphone: true,
+    geolocation: true,
+    fullscreen: true
+};
+const allowedPermissionKeys = new Set(Object.keys(permissionKeys));
 class ElementValidator {
     /**
      * Validate a element manifest
@@ -84,6 +104,15 @@ class ElementValidator {
             });
         }
         else {
+            Object.keys(manifest.permissions).forEach(key => {
+                if (!allowedPermissionKeys.has(key)) {
+                    errors.push({
+                        code: 'UNKNOWN_PERMISSION',
+                        message: `Unknown permission ${key} is not supported`,
+                        field: `permissions.${key}`
+                    });
+                }
+            });
             // Check for excessive permissions
             const permissionCount = Object.values(manifest.permissions).filter(v => v === true).length;
             if (permissionCount > 5) {

--- a/sdk/src/core/ElementValidator.test.ts
+++ b/sdk/src/core/ElementValidator.test.ts
@@ -1,0 +1,81 @@
+/** Tests manifest permission validation against declared and undeclared capabilities. */
+
+import { ElementValidator } from "./ElementValidator";
+import { ElementManifest } from "../interfaces";
+
+function makeManifest(
+  permissions: ElementManifest["permissions"]
+): ElementManifest {
+  return {
+    metadata: {
+      id: "safe-element",
+      name: "Safe Element",
+      version: "1.0.0",
+      author: "test",
+      description: "test",
+      category: "Utilities",
+      tags: [],
+      icon: "test",
+      minSize: { width: 100, height: 100 },
+      maxSize: { width: 200, height: 200 },
+      defaultSize: { width: 100, height: 100 },
+      tierRequired: "free",
+    },
+    permissions,
+  };
+}
+
+const noPermissions = {
+  network: false,
+  storage: false,
+  notifications: false,
+  clipboard: false,
+  canReceiveFrom: [],
+  canSendTo: [],
+  portfolio: false,
+  transactions: false,
+  aiChat: false,
+  wallet: false,
+};
+
+describe("ElementValidator permission validation", () => {
+  it("rejects undeclared permission keys", () => {
+    const manifest = makeManifest({
+      ...noPermissions,
+      filesystem: true,
+    } as ElementManifest["permissions"] & { filesystem: boolean });
+
+    const result = ElementValidator.validateManifest(manifest);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContainEqual({
+      code: "UNKNOWN_PERMISSION",
+      message: "Unknown permission filesystem is not supported",
+      field: "permissions.filesystem",
+    });
+  });
+
+  it("accepts manifests containing only declared permissions", () => {
+    const permissions = {
+      ...noPermissions,
+      maxMemory: 100,
+      maxCpu: 50,
+      maxStorageSize: 5,
+      camera: false,
+      microphone: false,
+      geolocation: false,
+      fullscreen: false,
+    } as ElementManifest["permissions"] & {
+      maxStorageSize: number;
+      camera: boolean;
+      microphone: boolean;
+      geolocation: boolean;
+      fullscreen: boolean;
+    };
+
+    const result = ElementValidator.validateManifest(makeManifest(permissions));
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+});

--- a/sdk/src/core/ElementValidator.ts
+++ b/sdk/src/core/ElementValidator.ts
@@ -5,10 +5,40 @@
 
 import {
   ElementManifest,
+  ElementPermissions,
   ElementValidationResult,
   ValidationError,
   ValidationWarning
 } from '../interfaces';
+
+type ManifestPermissionKey = keyof ElementPermissions |
+  'maxStorageSize' |
+  'camera' |
+  'microphone' |
+  'geolocation' |
+  'fullscreen';
+
+const permissionKeys: Record<ManifestPermissionKey, true> = {
+  network: true,
+  storage: true,
+  notifications: true,
+  clipboard: true,
+  canReceiveFrom: true,
+  canSendTo: true,
+  portfolio: true,
+  transactions: true,
+  aiChat: true,
+  wallet: true,
+  maxMemory: true,
+  maxCpu: true,
+  maxStorageSize: true,
+  camera: true,
+  microphone: true,
+  geolocation: true,
+  fullscreen: true
+};
+
+const allowedPermissionKeys = new Set(Object.keys(permissionKeys));
 
 export class ElementValidator {
   /**
@@ -93,6 +123,16 @@ export class ElementValidator {
         message: 'Element manifest must include permissions'
       });
     } else {
+      Object.keys(manifest.permissions).forEach(key => {
+        if (!allowedPermissionKeys.has(key)) {
+          errors.push({
+            code: 'UNKNOWN_PERMISSION',
+            message: `Unknown permission ${key} is not supported`,
+            field: `permissions.${key}`
+          });
+        }
+      });
+
       // Check for excessive permissions
       const permissionCount = Object.values(manifest.permissions).filter(v => v === true).length;
       if (permissionCount > 5) {
@@ -245,4 +285,4 @@ export class ElementValidator {
     
     return true;
   }
-} 
+}


### PR DESCRIPTION
## Outcome

**Harden** the SDK manifest validator so untrusted elements cannot smuggle undeclared capability names through `permissions` while appearing valid.

Package: `sdk` (`@defai/element-sdk`).  
Inheritance-app path: element manifest validation before permissioned host APIs and sandbox execution.

Closes #7. Leave approval and merge to `main` to `awidearray`; this is not accepted until that independent merge.

## Change

- Reject every permission key outside the declared SDK permission contract with `UNKNOWN_PERMISSION` and the exact `permissions.<key>` field.
- Preserve keys already published by `@defai/element-types` (`maxStorageSize`, camera, microphone, geolocation, and fullscreen) even though the SDK-local interface has not yet converged with that package.
- Add a real `ts-jest` SDK test harness and regression tests for both the denied unknown-key path and the allowed declared-key path.
- Regenerate the tracked SDK validator JavaScript.

No permission is widened, no host API is added, and runtime/sandbox enforcement remains unchanged.

## Evidence

Head: `18306e5ae45e94e0d64b9e4efb3ba4e80f5594bf`  
Base: `51a5d6eb16ce58e3d9d8866a7bb5c0af356abe7a` (`origin/main`)

### Failing before

Compiled the real `sdk/src` validator from `origin/main`, then called `ElementValidator.validateManifest()` with all declared permissions disabled plus `filesystem: true`:

```json
{
  "valid": true,
  "errors": [],
  "warnings": []
}
```

### Passing after

The identical manifest now returns:

```json
{
  "valid": false,
  "errors": [
    {
      "code": "UNKNOWN_PERMISSION",
      "message": "Unknown permission filesystem is not supported",
      "field": "permissions.filesystem"
    }
  ],
  "warnings": []
}
```

Commands run on the exact head above:

```text
npm run --workspace @defai/element-sdk test -- --runInBand --forceExit
PASS: 1 suite, 2 tests

npx tsc -p sdk/tsconfig.json --noEmit
PASS

npm run build
PASS: all 7 workspace builds

npm run test
FAIL (pre-existing): @defai/element-types runs `tsc --noEmit` without a tsconfig and exhausts the Node heap before the SDK lane runs. Tracked by #1 and PR #4.

npm run --workspace @defai/element-sdk lint
FAIL (pre-existing): ESLint cannot find a repository or package configuration.
```

## Remaining scope

- This does not reconcile the duplicate SDK/types permission interfaces; it preserves their current union for compatibility.
- It does not add value-type validation for each permission field.
- It does not modify the sandbox API exposure work covered by PR #5.

## Identity

- Provider: OpenAI
- Model: `gpt-5.6-sol`
- Client: Codex (`codex-cli 0.144.4`)
