### PR TITLE
fix(api): honor canSendTo allow-list on emit

### DIFF
--- a/sdk/jest.config.js
+++ b/sdk/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = { preset: 'ts-jest', testEnvironment: 'node', roots: ['<rootDir>/src'], testMatch: ['**/*.test.ts'] };

--- a/sdk/src/api/ElementAPIProxy.emit.test.ts
+++ b/sdk/src/api/ElementAPIProxy.emit.test.ts
@@ -1,0 +1,103 @@
+import { ElementAPIProxy } from './ElementAPIProxy';
+import { ElementAPI, ElementPermissions } from '../interfaces';
+
+function createPermissions(
+  overrides: Partial<ElementPermissions> = {}
+): ElementPermissions {
+  return {
+    network: false,
+    storage: false,
+    notifications: false,
+    clipboard: false,
+    canReceiveFrom: [],
+    canSendTo: [],
+    portfolio: false,
+    transactions: false,
+    aiChat: false,
+    wallet: false,
+    ...overrides
+  };
+}
+
+function createMockAPI(): jest.Mocked<ElementAPI> {
+  return {
+    getPortfolio: jest.fn(),
+    getTransactions: jest.fn(),
+    getPrices: jest.fn(),
+    saveData: jest.fn(),
+    loadData: jest.fn(),
+    sendNotification: jest.fn(),
+    analyzeImage: jest.fn(),
+    analyzeToken: jest.fn(),
+    emit: jest.fn(),
+    on: jest.fn()
+  };
+}
+
+describe('ElementAPIProxy.emit canSendTo allow-list', () => {
+  const elementId = 'sender-element';
+
+  it('denies emit when canSendTo is empty and does not call actualAPI.emit', () => {
+    const actualAPI = createMockAPI();
+    const proxy = new ElementAPIProxy(
+      elementId,
+      createPermissions({ canSendTo: [] }),
+      actualAPI
+    );
+
+    expect(() => proxy.emit('ping', { hello: true })).toThrow(
+      'Element cannot send events'
+    );
+    expect(actualAPI.emit).not.toHaveBeenCalled();
+  });
+
+  it('denies emit when canSendTo is missing and does not call actualAPI.emit', () => {
+    const actualAPI = createMockAPI();
+    const permissions = createPermissions();
+    delete (permissions as Partial<ElementPermissions>).canSendTo;
+    const proxy = new ElementAPIProxy(elementId, permissions, actualAPI);
+
+    expect(() => proxy.emit('ping', { hello: true })).toThrow(
+      'Element cannot send events'
+    );
+    expect(actualAPI.emit).not.toHaveBeenCalled();
+  });
+
+  it('allows emit when canSendTo includes wildcard *', () => {
+    const actualAPI = createMockAPI();
+    const proxy = new ElementAPIProxy(
+      elementId,
+      createPermissions({ canSendTo: ['*'] }),
+      actualAPI
+    );
+
+    proxy.emit('ping', { hello: true });
+
+    expect(actualAPI.emit).toHaveBeenCalledTimes(1);
+    expect(actualAPI.emit).toHaveBeenCalledWith('ping', {
+      source: elementId,
+      data: { hello: true }
+    });
+  });
+
+  it('attaches destinations from a specific canSendTo list', () => {
+    const actualAPI = createMockAPI();
+    const canSendTo = ['trusted-element', 'other-element'];
+    const proxy = new ElementAPIProxy(
+      elementId,
+      createPermissions({ canSendTo }),
+      actualAPI
+    );
+
+    proxy.emit('ping', { hello: true });
+
+    expect(actualAPI.emit).toHaveBeenCalledTimes(1);
+    expect(actualAPI.emit).toHaveBeenCalledWith('ping', {
+      source: elementId,
+      destinations: ['trusted-element', 'other-element'],
+      data: { hello: true }
+    });
+    const payload = actualAPI.emit.mock.calls[0][1];
+    expect(payload.destinations).not.toBe(canSendTo);
+  });
+});

--- a/sdk/src/api/ElementAPIProxy.ts
+++ b/sdk/src/api/ElementAPIProxy.ts
@@ -84,16 +84,23 @@ export class ElementAPIProxy implements ElementAPI {
   }
 
   emit(event: string, data: any): void {
-    // Check if element can send to others
-    if (this.permissions.canSendTo.length === 0) {
+    const canSendTo = this.permissions.canSendTo;
+    if (!Array.isArray(canSendTo) || canSendTo.length === 0) {
       throw new Error('Element cannot send events');
     }
-    
-    // Include source element ID
-    this.actualAPI.emit(event, {
+
+    const payload: { source: string; data: any; destinations?: string[] } = {
       source: this.elementId,
       data
-    });
+    };
+
+    // '*' is a wildcard grant. Specific IDs are attached so the host can enforce
+    // routing; never treat a non-empty list as an implicit broadcast.
+    if (!canSendTo.includes('*')) {
+      payload.destinations = [...canSendTo];
+    }
+
+    this.actualAPI.emit(event, payload);
   }
 
   on(event: string, handler: (data: any) => void): () => void {


### PR DESCRIPTION
## Summary
- `ElementAPIProxy.emit` treated any non-empty `canSendTo` as a global send grant.
- Empty/missing lists now deny; `*` remains wildcard; specific IDs are attached as `destinations` on the payload.

## Test plan
- Jest: `sdk/src/api/ElementAPIProxy.emit.test.ts`

## Agent
- client: grok (Grok Build)
- provider: xai
- model: grok-4.6
- unmeasured (heir-elements-sdk receipt policy pending-authority)

Do not merge.