### PR TITLE
fix(cli): reject unknown permissions using SDK keys

### DIFF
--- a/cli/src/commands/permissionKeys.ts
+++ b/cli/src/commands/permissionKeys.ts
@@ -1,0 +1,21 @@
+/** Keys of SDK `ElementPermissions` (sdk/src/interfaces/index.ts). */
+export const VALID_PERMISSION_KEYS = [
+  'network',
+  'storage',
+  'notifications',
+  'clipboard',
+  'canReceiveFrom',
+  'canSendTo',
+  'portfolio',
+  'transactions',
+  'aiChat',
+  'wallet',
+  'maxMemory',
+  'maxCpu',
+] as const;
+
+export type ValidPermissionKey = (typeof VALID_PERMISSION_KEYS)[number];
+
+export function isValidPermissionKey(key: string): key is ValidPermissionKey {
+  return (VALID_PERMISSION_KEYS as readonly string[]).includes(key);
+}

--- a/cli/src/commands/validate.permissions.test.ts
+++ b/cli/src/commands/validate.permissions.test.ts
@@ -1,0 +1,47 @@
+import {
+  VALID_PERMISSION_KEYS,
+  isValidPermissionKey,
+} from './permissionKeys';
+
+const SDK_PERMISSION_KEYS = [
+  'network',
+  'storage',
+  'notifications',
+  'clipboard',
+  'canReceiveFrom',
+  'canSendTo',
+  'portfolio',
+  'transactions',
+  'aiChat',
+  'wallet',
+  'maxMemory',
+  'maxCpu',
+] as const;
+
+describe('CLI validate permission keys', () => {
+  it('allows only SDK ElementPermissions keys', () => {
+    expect([...VALID_PERMISSION_KEYS].sort()).toEqual(
+      [...SDK_PERMISSION_KEYS].sort()
+    );
+  });
+
+  it('accepts every SDK permission key', () => {
+    for (const key of SDK_PERMISSION_KEYS) {
+      expect(isValidPermissionKey(key)).toBe(true);
+    }
+  });
+
+  it('rejects former CLI keys that are not on ElementPermissions', () => {
+    expect(isValidPermissionKey('ai')).toBe(false);
+    expect(isValidPermissionKey('messaging')).toBe(false);
+  });
+
+  it('rejects unknown and types-package extra keys', () => {
+    expect(isValidPermissionKey('camera')).toBe(false);
+    expect(isValidPermissionKey('microphone')).toBe(false);
+    expect(isValidPermissionKey('geolocation')).toBe(false);
+    expect(isValidPermissionKey('fullscreen')).toBe(false);
+    expect(isValidPermissionKey('maxStorageSize')).toBe(false);
+    expect(isValidPermissionKey('notARealPermission')).toBe(false);
+  });
+});

--- a/cli/src/commands/validate.ts
+++ b/cli/src/commands/validate.ts
@@ -2,6 +2,9 @@ import fs from 'fs-extra';
 import path from 'path';
 import chalk from 'chalk';
 import ora from 'ora';
+import { isValidPermissionKey } from './permissionKeys';
+
+export { VALID_PERMISSION_KEYS, isValidPermissionKey } from './permissionKeys';
 
 export interface ValidateOptions {
   strict: boolean;
@@ -95,13 +98,12 @@ export class ValidateCommand {
         }
       }
 
-      // Validate permissions
+      // Validate permissions against SDK ElementPermissions keys
       if (manifest.permissions) {
-        const validPermissions = ['wallet', 'network', 'ai', 'storage', 'notifications', 'messaging'];
         for (const permission of Object.keys(manifest.permissions)) {
-          if (!validPermissions.includes(permission)) {
+          if (!isValidPermissionKey(permission)) {
             issues.push({
-              type: 'warning',
+              type: 'error',
               message: `Unknown permission in manifest.json: ${permission}`
             });
           }


### PR DESCRIPTION
## Summary
- CLI `validate` allowed a stale permission list (`wallet`, `network`, `ai`, `storage`, `notifications`, `messaging`) and treated unknown keys as warnings.
- Allowed keys now match SDK `ElementPermissions`: `network`, `storage`, `notifications`, `clipboard`, `canReceiveFrom`, `canSendTo`, `portfolio`, `transactions`, `aiChat`, `wallet`, `maxMemory`, `maxCpu`.
- Unknown permission keys are type errors so a permissioned inheritance sandbox cannot silently accept extra grants.
- Required-field checks are unchanged.

## Test plan
- Jest: `cli/src/commands/validate.permissions.test.ts` (helper-only; no ora/fs)
- Command: `node node_modules/jest/bin/jest.js --config='{"preset":"ts-jest","testEnvironment":"node","testMatch":["**/validate.permissions.test.ts"],"rootDir":"cli"}'`
- Result: 4 passed

## Agent
- client: grok (Grok Build)
- provider: xai
- model: grok-4.6
- unmeasured (no receipts)

Do not merge.