### PR TITLE
fix(events): reject non-integer history caps and isolate getHistory copies

### DIFF
--- a/sdk/jest.config.js
+++ b/sdk/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/src/**/*.test.ts']
+};

--- a/sdk/src/utils/eventEmitter.test.ts
+++ b/sdk/src/utils/eventEmitter.test.ts
@@ -1,0 +1,104 @@
+import { ElementEventEmitter } from './eventEmitter';
+
+describe('ElementEventEmitter history', () => {
+  let emitter: ElementEventEmitter;
+
+  beforeEach(() => {
+    emitter = new ElementEventEmitter();
+  });
+
+  describe('setMaxHistorySize', () => {
+    const invalidSizes = [
+      ['NaN', Number.NaN],
+      ['Infinity', Number.POSITIVE_INFINITY],
+      ['-Infinity', Number.NEGATIVE_INFINITY],
+      ['negative integer', -1],
+      ['negative float', -0.5],
+      ['positive float', 1.5]
+    ] as const;
+
+    it.each(invalidSizes)('rejects %s', (_label, size) => {
+      expect(() => emitter.setMaxHistorySize(size)).toThrow(TypeError);
+      expect(() => emitter.setMaxHistorySize(size)).toThrow(
+        /finite non-negative integer/
+      );
+    });
+
+    it('accepts 0 and finite non-negative integers', () => {
+      expect(() => emitter.setMaxHistorySize(0)).not.toThrow();
+      expect(() => emitter.setMaxHistorySize(1)).not.toThrow();
+      expect(() => emitter.setMaxHistorySize(100)).not.toThrow();
+    });
+
+    it('trims existing history when the cap is lowered', () => {
+      emitter.emit('a', { n: 1 });
+      emitter.emit('b', { n: 2 });
+      emitter.emit('c', { n: 3 });
+
+      emitter.setMaxHistorySize(2);
+
+      const history = emitter.getHistory();
+      expect(history).toHaveLength(2);
+      expect(history.map((entry) => entry.event)).toEqual(['b', 'c']);
+    });
+
+    it('drops the oldest event once the emit cap is exceeded', () => {
+      emitter.setMaxHistorySize(2);
+      emitter.emit('a', 1);
+      emitter.emit('b', 2);
+      emitter.emit('c', 3);
+
+      const history = emitter.getHistory();
+      expect(history).toHaveLength(2);
+      expect(history.map((entry) => entry.event)).toEqual(['b', 'c']);
+    });
+  });
+
+  describe('getHistory', () => {
+    it('defaults maxHistorySize to 100', () => {
+      for (let i = 0; i < 101; i += 1) {
+        emitter.emit('tick', i);
+      }
+
+      const history = emitter.getHistory();
+      expect(history).toHaveLength(100);
+      expect(history[0].data).toBe(1);
+      expect(history[99].data).toBe(100);
+    });
+
+    it('returns isolated copies of stored records', () => {
+      const payload = { value: 1 };
+      emitter.emit('change', payload);
+
+      const snapshot = emitter.getHistory();
+      expect(snapshot).toHaveLength(1);
+      expect(snapshot[0]).not.toBe(emitter.getHistory()[0]);
+
+      snapshot[0].event = 'mutated';
+      snapshot[0].data = { value: 99 };
+      snapshot[0].timestamp = 0;
+      snapshot.pop();
+
+      const stored = emitter.getHistory();
+      expect(stored).toHaveLength(1);
+      expect(stored[0].event).toBe('change');
+      expect(stored[0].data).toBe(payload);
+      expect(stored[0].timestamp).not.toBe(0);
+    });
+
+    it('isolates filtered history records as well', () => {
+      emitter.emit('keep', { id: 1 });
+      emitter.emit('drop', { id: 2 });
+
+      const filtered = emitter.getHistory('keep');
+      expect(filtered).toHaveLength(1);
+      filtered[0].event = 'mutated';
+      filtered[0].data = { id: 9 };
+
+      const stored = emitter.getHistory('keep');
+      expect(stored).toHaveLength(1);
+      expect(stored[0].event).toBe('keep');
+      expect(stored[0].data).toEqual({ id: 1 });
+    });
+  });
+});

--- a/sdk/src/utils/eventEmitter.ts
+++ b/sdk/src/utils/eventEmitter.ts
@@ -35,13 +35,18 @@ export class ElementEventEmitter extends EventEmitter {
   }
 
   /**
-   * Get event history
+   * Get event history as shallow copies of each record so callers cannot
+   * mutate stored entries.
    */
   getHistory(event?: string): Array<{ event: string; data: any; timestamp: number }> {
-    if (event) {
-      return this.eventHistory.filter(e => e.event === event);
-    }
-    return [...this.eventHistory];
+    const records = event
+      ? this.eventHistory.filter(e => e.event === event)
+      : this.eventHistory;
+    return records.map(({ event: name, data, timestamp }) => ({
+      event: name,
+      data,
+      timestamp
+    }));
   }
 
   /**
@@ -55,7 +60,12 @@ export class ElementEventEmitter extends EventEmitter {
    * Set maximum history size
    */
   setMaxHistorySize(size: number): void {
-    this.maxHistorySize = Math.max(0, size);
+    if (!Number.isFinite(size) || size < 0 || !Number.isInteger(size)) {
+      throw new TypeError(
+        'maxHistorySize must be a finite non-negative integer'
+      );
+    }
+    this.maxHistorySize = size;
     // Trim existing history if needed
     while (this.eventHistory.length > this.maxHistorySize) {
       this.eventHistory.shift();


### PR DESCRIPTION
## Summary
- `setMaxHistorySize` used `Math.max(0, size)`, so `NaN` became the cap and `Infinity` disabled trimming.
- Caps now require `Number.isFinite(size) && size >= 0 && Number.isInteger(size)`; otherwise throw.
- `getHistory` returns `{ event, data, timestamp }` copies of each record so callers cannot mutate stored history.
- Default `maxHistorySize` remains 100.

## Test plan
- Jest: `sdk/src/utils/eventEmitter.test.ts` (rejects NaN/Infinity/negative/float; cap trims; getHistory isolation)

## Agent
- client: grok (Grok Build)
- provider: xai
- model: grok-4.6
- unmeasured

Do not merge.