### PR TITLE
fix(testing): default mock permissions to deny-all and reject unknown keys

### DIFF
--- a/testing/jest.config.js
+++ b/testing/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/src/**/*.test.ts']
+};

--- a/testing/src/index.test.ts
+++ b/testing/src/index.test.ts
@@ -1,0 +1,155 @@
+import { createTestElement } from './index';
+
+const SDK_PERMISSION_KEYS = [
+  'network',
+  'storage',
+  'notifications',
+  'clipboard',
+  'canReceiveFrom',
+  'canSendTo',
+  'portfolio',
+  'transactions',
+  'aiChat',
+  'wallet',
+  'maxMemory',
+  'maxCpu',
+] as const;
+
+const DEFAULT_BOOLEAN_KEYS = [
+  'network',
+  'storage',
+  'notifications',
+  'clipboard',
+  'portfolio',
+  'transactions',
+  'aiChat',
+  'wallet',
+] as const;
+
+describe('createTestElement permissions', () => {
+  it('defaults every boolean permission to false', () => {
+    const element = createTestElement();
+
+    for (const key of DEFAULT_BOOLEAN_KEYS) {
+      expect(element.permissions[key]).toBe(false);
+    }
+  });
+
+  it('defaults canReceiveFrom and canSendTo to empty arrays', () => {
+    const element = createTestElement();
+
+    expect(element.permissions.canReceiveFrom).toEqual([]);
+    expect(element.permissions.canSendTo).toEqual([]);
+  });
+
+  it('does not set maxMemory or maxCpu unless overridden', () => {
+    const element = createTestElement();
+
+    expect(Object.prototype.hasOwnProperty.call(element.permissions, 'maxMemory')).toBe(
+      false
+    );
+    expect(Object.prototype.hasOwnProperty.call(element.permissions, 'maxCpu')).toBe(
+      false
+    );
+    expect('maxMemory' in element.permissions).toBe(false);
+    expect('maxCpu' in element.permissions).toBe(false);
+  });
+
+  it('does not share default allow-list arrays across instances', () => {
+    const first = createTestElement();
+    const second = createTestElement();
+
+    first.permissions.canReceiveFrom.push('other-element');
+    first.permissions.canSendTo.push('other-element');
+
+    expect(second.permissions.canReceiveFrom).toEqual([]);
+    expect(second.permissions.canSendTo).toEqual([]);
+  });
+
+  it('applies known permission overrides including resource limits', () => {
+    const element = createTestElement({
+      permissions: {
+        storage: true,
+        network: true,
+        canReceiveFrom: ['alpha'],
+        canSendTo: ['beta'],
+        maxMemory: 32,
+        maxCpu: 10,
+      },
+    });
+
+    expect(element.permissions.storage).toBe(true);
+    expect(element.permissions.network).toBe(true);
+    expect(element.permissions.canReceiveFrom).toEqual(['alpha']);
+    expect(element.permissions.canSendTo).toEqual(['beta']);
+    expect(element.permissions.maxMemory).toBe(32);
+    expect(element.permissions.maxCpu).toBe(10);
+    expect(element.permissions.wallet).toBe(false);
+  });
+
+  it('keeps only SDK permission keys on the merged result', () => {
+    const element = createTestElement({
+      permissions: {
+        wallet: true,
+        maxMemory: 8,
+      },
+    });
+
+    expect(Object.keys(element.permissions).sort()).toEqual(
+      [...SDK_PERMISSION_KEYS.filter((key) => key !== 'maxCpu')].sort()
+    );
+  });
+
+  it('throws naming each unknown permission key', () => {
+    expect(() =>
+      createTestElement({
+        permissions: {
+          camera: true,
+          admin: true,
+        },
+      })
+    ).toThrow(/Unknown permission key\(s\): camera, admin/);
+  });
+
+  it('rejects types-package extras and former non-SDK keys', () => {
+    for (const key of [
+      'camera',
+      'microphone',
+      'geolocation',
+      'fullscreen',
+      'maxStorageSize',
+      'ai',
+      'messaging',
+    ]) {
+      expect(() => createTestElement({ permissions: { [key]: true } })).toThrow(
+        new RegExp(`Unknown permission key\\(s\\): ${key}`)
+      );
+    }
+  });
+
+  it('rejects prototype-pollution keys without mutating Object.prototype', () => {
+    const payload = JSON.parse('{"__proto__": {"polluted": true}, "admin": true}');
+
+    expect(() => createTestElement({ permissions: payload })).toThrow(
+      /Unknown permission key\(s\): __proto__, admin/
+    );
+    expect(Object.prototype.hasOwnProperty('polluted')).toBe(false);
+    expect(({} as { polluted?: boolean }).polluted).toBeUndefined();
+  });
+
+  it('uses a null-prototype permissions object', () => {
+    const element = createTestElement();
+
+    expect(Object.getPrototypeOf(element.permissions)).toBeNull();
+  });
+
+  it('still merges metadata overrides', () => {
+    const element = createTestElement({
+      metadata: { id: 'custom-element', name: 'Custom' },
+    });
+
+    expect(element.metadata.id).toBe('custom-element');
+    expect(element.metadata.name).toBe('Custom');
+    expect(element.metadata.version).toBe('1.0.0');
+  });
+});

--- a/testing/src/index.ts
+++ b/testing/src/index.ts
@@ -5,7 +5,71 @@
 
 export { createMockContext } from '@defai/element-sdk';
 
-export function createTestElement(overrides?: any) {
+/** Keys of SDK `ElementPermissions` (sdk/src/interfaces/index.ts). */
+const SDK_PERMISSION_KEYS = [
+  'network',
+  'storage',
+  'notifications',
+  'clipboard',
+  'canReceiveFrom',
+  'canSendTo',
+  'portfolio',
+  'transactions',
+  'aiChat',
+  'wallet',
+  'maxMemory',
+  'maxCpu',
+] as const;
+
+const SDK_PERMISSION_KEY_SET: ReadonlySet<string> = new Set(SDK_PERMISSION_KEYS);
+
+function copyOwnProperties(source: object): Record<string, unknown> {
+  const copy = Object.create(null) as Record<string, unknown>;
+  for (const key of Object.keys(source)) {
+    copy[key] = (source as Record<string, unknown>)[key];
+  }
+  return copy;
+}
+
+function mergePermissions(overrides?: object): Record<string, unknown> {
+  const permissions = Object.create(null) as Record<string, unknown>;
+  permissions.network = false;
+  permissions.storage = false;
+  permissions.notifications = false;
+  permissions.clipboard = false;
+  permissions.canReceiveFrom = [];
+  permissions.canSendTo = [];
+  permissions.portfolio = false;
+  permissions.transactions = false;
+  permissions.aiChat = false;
+  permissions.wallet = false;
+
+  if (overrides == null) {
+    return permissions;
+  }
+
+  const overrideCopy = copyOwnProperties(overrides);
+  const unknownKeys = Object.keys(overrideCopy).filter(
+    (key) => !SDK_PERMISSION_KEY_SET.has(key)
+  );
+
+  if (unknownKeys.length > 0) {
+    throw new Error(`Unknown permission key(s): ${unknownKeys.join(', ')}`);
+  }
+
+  for (const key of SDK_PERMISSION_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(overrideCopy, key)) {
+      permissions[key] = overrideCopy[key];
+    }
+  }
+
+  return permissions;
+}
+
+export function createTestElement(overrides?: any): {
+  metadata: any;
+  permissions: any;
+} {
   return {
     metadata: {
       id: 'test-element',
@@ -22,18 +86,6 @@ export function createTestElement(overrides?: any) {
       tierRequired: 'free',
       ...overrides?.metadata
     },
-    permissions: {
-      network: false,
-      storage: true,
-      notifications: false,
-      clipboard: false,
-      canReceiveFrom: [],
-      canSendTo: [],
-      portfolio: false,
-      transactions: false,
-      aiChat: false,
-      wallet: false,
-      ...overrides?.permissions
-    }
+    permissions: mergePermissions(overrides?.permissions)
   };
-} 
+}


### PR DESCRIPTION
## Summary
- `createTestElement` defaulted `storage: true` and spread `overrides.permissions`, so tests silently got persistence and could inherit unknown keys (`camera`, `admin`) or `__proto__` via object assign.
- Defaults are now deny-all: every boolean is `false`, `canReceiveFrom`/`canSendTo` are empty arrays, and `maxMemory`/`maxCpu` are omitted unless overridden.
- After merge, only SDK `ElementPermissions` keys are kept: `network`, `storage`, `notifications`, `clipboard`, `canReceiveFrom`, `canSendTo`, `portfolio`, `transactions`, `aiChat`, `wallet`, `maxMemory`, `maxCpu`.
- Unknown keys throw with the unknown key names. Overrides are copied onto `Object.create(null)` so `__proto__` cannot pollute `Object.prototype`.

## Test plan
- Jest: `testing/src/index.test.ts`
- Command: `npm test --workspace=@defai/element-testing`
- Result: 11 passed

## Agent
- client: grok (Grok Build)
- provider: xai
- model: grok-4.6
- unmeasured (no receipts)

Do not merge.