### PR TITLE
fix(validator): reject unknown permission keys in manifest validation

### DIFF
--- a/sdk/__tests__/ElementValidator.permissions.test.ts
+++ b/sdk/__tests__/ElementValidator.permissions.test.ts
@@ -1,0 +1,77 @@
+/**
+ * ElementValidator tests — permission key validation
+ * Regression test for: validator accepts unknown permission keys
+ */
+import { ElementValidator } from '../src/core/ElementValidator';
+import { ElementManifest } from '../src/interfaces';
+
+function validManifest(overrides: Partial<ElementManifest> = {}): ElementManifest {
+  return {
+    metadata: {
+      id: 'test-element',
+      name: 'Test Element',
+      version: '1.0.0',
+      author: 'tester',
+      description: 'A test element',
+      category: 'widget',
+      tags: [],
+      icon: 'icon.svg',
+      minSize: { width: 100, height: 100 },
+      maxSize: { width: 200, height: 200 },
+      defaultSize: { width: 150, height: 150 },
+      tierRequired: 'free',
+    },
+    permissions: {
+      network: true,
+      storage: false,
+      notifications: false,
+      clipboard: false,
+      canReceiveFrom: [],
+      canSendTo: [],
+      portfolio: false,
+      transactions: false,
+      aiChat: false,
+      wallet: false,
+    },
+    ...overrides,
+  } as ElementManifest;
+}
+
+describe('ElementValidator.validateManifest permission keys', () => {
+  it('accepts a manifest with only declared permission keys', () => {
+    const result = ElementValidator.validateManifest(validManifest());
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('rejects an unknown permission key (deny-by-default)', () => {
+    const manifest = validManifest();
+    // Inject an undeclared capability, as an untrusted manifest would
+    (manifest.permissions as any).filesystem = true;
+    const result = ElementValidator.validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.code === 'UNKNOWN_PERMISSION')).toBe(true);
+  });
+
+  it('rejects multiple unknown permission keys with field-specific errors', () => {
+    const manifest = validManifest();
+    (manifest.permissions as any).filesystem = true;
+    (manifest.permissions as any).camera = true;
+    const result = ElementValidator.validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    const unknownErrors = result.errors.filter(e => e.code === 'UNKNOWN_PERMISSION');
+    expect(unknownErrors).toHaveLength(2);
+  });
+
+  it('accepts declared keys alongside resource limits', () => {
+    const manifest = validManifest({
+      permissions: {
+        ...validManifest().permissions,
+        maxMemory: 64,
+        maxCpu: 25,
+      },
+    });
+    const result = ElementValidator.validateManifest(manifest);
+    expect(result.valid).toBe(true);
+  });
+});

--- a/sdk/jest.config.js
+++ b/sdk/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/**/*.test.ts'],
+};

--- a/sdk/src/core/ElementValidator.ts
+++ b/sdk/src/core/ElementValidator.ts
@@ -93,6 +93,40 @@ export class ElementValidator {
         message: 'Element manifest must include permissions'
       });
     } else {
+      // Deny-by-default: reject unknown permission keys before any other
+      // permission processing. The runtime's ElementPermissions contract has
+      // a closed set of host capabilities, so validator input must not
+      // silently carry undeclared capability names through an untrusted
+      // manifest.
+      const declaredPermissionKeys = new Set([
+        // API access
+        'network',
+        'storage',
+        'notifications',
+        'clipboard',
+        // Inter-element communication
+        'canReceiveFrom',
+        'canSendTo',
+        // Data access
+        'portfolio',
+        'transactions',
+        'aiChat',
+        'wallet',
+        // Resource limits
+        'maxMemory',
+        'maxCpu',
+      ]);
+
+      Object.keys(manifest.permissions).forEach(key => {
+        if (!declaredPermissionKeys.has(key)) {
+          errors.push({
+            code: 'UNKNOWN_PERMISSION',
+            message: `Unknown permission key: ${key}`,
+            field: `permissions.${key}`
+          });
+        }
+      });
+
       // Check for excessive permissions
       const permissionCount = Object.values(manifest.permissions).filter(v => v === true).length;
       if (permissionCount > 5) {


### PR DESCRIPTION
## Summary

Fixes #7: `ElementValidator.validateManifest` accepted arbitrary keys inside `manifest.permissions` (e.g. `filesystem: true`) and returned `valid: true`. This is a deny-by-default boundary — the runtime's `ElementPermissions` contract has a closed set of host capabilities, so validator input must reject unknown permission names instead of silently carrying them through an untrusted manifest.

## Changes

- `sdk/src/core/ElementValidator.ts`: added a closed set of declared permission keys (network, storage, notifications, clipboard, canReceiveFrom, canSendTo, portfolio, transactions, aiChat, wallet, maxMemory, maxCpu). Any unknown key now produces a field-specific `UNKNOWN_PERMISSION` error.
- `sdk/__tests__/ElementValidator.permissions.test.ts`: new SDK validator tests — declared-keys control manifest, single unknown key, multiple unknown keys, and declared keys with resource limits.
- `sdk/jest.config.js`: ts-jest config so the SDK test suite can run.

## Evidence

- **Provider/model/client**: Hermes Agent (Nous Research), model deepseek-v4-flash, client Hermes (manual/CLI agent).
- **Before**: `ElementValidator.validateManifest` with `permissions: { ...declared, filesystem: true }` → `{"valid":true,"errors":[]}` (reproduced locally; failing test in `ElementValidator.permissions.test.ts`).
- **After**: same manifest → `{"valid":false,"errors":[{"code":"UNKNOWN_PERMISSION","field":"permissions.filesystem"}]}`. All 4 tests pass.
- **Build**: `npm run build` (tsc) in `sdk/` passes clean.
- **Test**: `npx jest` in `sdk/` → 4 passed, 0 failed.

## Scope

- Runtime permission enforcement and permission widening left out of scope (per issue evidence plan).
- Note: `@defai/element-types` test fails at repo root with `tsc --noEmit` (no tsconfig in `types/`); this pre-exists (see #1) and is unrelated to this change.

Fixes #7