### PR TITLE
fix(validator): reject unknown permission keys in ElementValidator

### DIFF
--- a/sdk/__tests__/ElementValidator.permissions.test.ts
+++ b/sdk/__tests__/ElementValidator.permissions.test.ts
@@ -1,0 +1,50 @@
+import { ElementValidator } from '../src/core/ElementValidator';
+
+describe('ElementValidator permissions', () => {
+  it('rejects unknown permission keys (deny-by-default)', () => {
+    const manifest = {
+      name: 'test',
+      version: '1.0.0',
+      permissions: {
+        network: false,
+        filesystem: true, // undeclared capability
+      },
+    } as any;
+
+    const result = ElementValidator.validateManifest(manifest);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.code === 'UNKNOWN_PERMISSION')).toBe(true);
+  });
+
+  it('accepts only known permission keys', () => {
+    const manifest = {
+      name: 'test',
+      version: '1.0.0',
+      permissions: {
+        network: true,
+        storage: false,
+      },
+    } as any;
+
+    const result = ElementValidator.validateManifest(manifest);
+    expect(result.errors.filter(e => e.code === 'UNKNOWN_PERMISSION').length).toBe(0);
+  });
+
+  it('reports the unknown key name in the error', () => {
+    const manifest = {
+      name: 'test',
+      version: '1.0.0',
+      permissions: {
+        network: false,
+        clipboard: true,
+        camera: true,
+      },
+    } as any;
+
+    const result = ElementValidator.validateManifest(manifest);
+    const unknown = result.errors.find(e => e.code === 'UNKNOWN_PERMISSION');
+    expect(unknown).toBeDefined();
+    expect(unknown?.message).toContain('camera');
+    expect(unknown?.field).toBe('permissions.camera');
+  });
+});

--- a/sdk/jest.config.js
+++ b/sdk/jest.config.js
@@ -1,0 +1,9 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/**/*.test.ts'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.json' }],
+  },
+};

--- a/sdk/src/core/ElementValidator.ts
+++ b/sdk/src/core/ElementValidator.ts
@@ -93,6 +93,33 @@ export class ElementValidator {
         message: 'Element manifest must include permissions'
       });
     } else {
+      // Deny-by-default: reject unknown permission keys instead of silently
+      // carrying them through an untrusted manifest. The runtime's
+      // ElementPermissions contract has a closed set of host capabilities.
+      const knownPermissionKeys = new Set([
+        'network',
+        'storage',
+        'notifications',
+        'clipboard',
+        'canReceiveFrom',
+        'canSendTo',
+        'portfolio',
+        'transactions',
+        'aiChat',
+        'wallet',
+        'maxMemory',
+        'maxCpu',
+      ]);
+      Object.keys(manifest.permissions).forEach((key) => {
+        if (!knownPermissionKeys.has(key)) {
+          errors.push({
+            code: 'UNKNOWN_PERMISSION',
+            message: `Element requests unknown permission '${key}'`,
+            field: `permissions.${key}`,
+          });
+        }
+      });
+
       // Check for excessive permissions
       const permissionCount = Object.values(manifest.permissions).filter(v => v === true).length;
       if (permissionCount > 5) {


### PR DESCRIPTION
## Problem
`sdk/src/core/ElementValidator.ts` accepts arbitrary keys inside `manifest.permissions`. It counts only boolean values and returns a valid result for a manifest containing an undeclared capability such as `filesystem: true`. This is a deny-by-default boundary: the runtime's `ElementPermissions` contract has a closed set of host capabilities, so validator input should reject unknown permission names instead of silently carrying them through an untrusted manifest.

## Fix
- Add a known-permission-key check (network, storage, notifications, clipboard, canReceiveFrom, canSendTo, portfolio, transactions, aiChat, wallet, maxMemory, maxCpu)
- Push an `UNKNOWN_PERMISSION` error (with `permissions.<key>` field) for any undeclared key
- Add jest coverage: rejection of unknown keys, acceptance of known keys, error message/field content

## Verification
`npx jest __tests__/ElementValidator.permissions.test.ts` — 3/3 passing.

Closes #7

---
AI provider/model: deepseek-v4-flash
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-heir-elements-sdk